### PR TITLE
Update config.ini

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -35,11 +35,177 @@ data_refresh_limit = 1
 
 # expand to include all platforms you need
 [platforms]
-PC
-PlayStation
-Xbox
-Nintendo
-VR
+Acorn - Archimedes
+Acorn - Atom
+Acorn - Risc PC
+ACT - Apricot PC Xi
+Amstrad - CPC
+APF - Imagination Machine
+APF - MP-1000
+Apple - I
+Apple - II
+Apple - IIe
+Apple - IIGS
+Apple - Macintosh
+Arduboy Inc - Arduboy
+Atari - 2600
+Atari - 5200
+Atari - 7800
+Atari - 8-bit Family
+Atari - Jaguar
+Atari - Jaguar CD Interactive Multimedia System
+Atari - Lynx
+Atari - ST
+Bally - Astrocade
+Bandai - Design Master Denshi Mangajuku
+Bandai - Gundam RX-78
+Bandai - Pippin
+Bandai - Playdia Quick Interactive System
+Bandai - WonderSwan
+Bandai - WonderSwan Color
+Benesse - Pocket Challenge V2
+Benesse - Pocket Challenge W
+Bit Corporation - Gamate
+Casio - Loopy
+Casio - PV-1000
+Coleco - ColecoVision
+Commodore - Amiga
+Commodore - Amiga CD
+Commodore - Amiga CD32
+Commodore - Amiga CDTV
+Commodore - Commodore 64
+Commodore - Plus-4
+Commodore - VIC-20
+Digital Media Cartridge - Firecore
+Emerson - Arcadia 2001
+Entex - Adventure Vision
+Epoch - Game Pocket Computer
+Epoch - Super Cassette Vision
+Fairchild - Channel F
+Fujitsu - FM-7
+Fujitsu - FM-Towns
+Fujitsu - FMR50
+Fukutake Publishing - StudyBox
+Funtech - Super Acan
+Funworld - Photo Play
+GamePark - GP2X
+GamePark - GP32
+GCE - Vectrex
+Hartung - Game Master
+Hitachi - S1
+Incredible Technologies - Eagle
+Interton - VC 4000
+Konami - Picno
+LeapFrog - Explorer
+LeapFrog - LeapPad
+LeapFrog - Leapster Learning Game System
+Luxor - ABC 800
+Magnavox - Odyssey 2
+Mattel - Fisher-Price iXL
+Mattel - HyperScan
+Mattel - Intellivision
+Memorex - Visual Information System
+Microsoft - MSX
+Microsoft - MSX2
+Microsoft - Xbox
+Microsoft - Xbox 360
+Microsoft - Xbox One
+Microsoft - Xbox Series X
+Milton-Bradley - Omni
+Mobile - J2ME
+Mobile - Palm OS
+Mobile - Pocket PC
+Mobile - Symbian
+NEC - PC Engine - TurboGrafx-16
+NEC - PC Engine CD & TurboGrafx CD
+NEC - PC Engine SuperGrafx
+NEC - PC-88 series
+NEC - PC-98 series
+NEC - PC-FX & PC-FXGA
+Nichibutsu - My Vision
+Nintendo - 3DS
+Nintendo - 64
+Nintendo - 64 DiskDrive
+Nintendo - DS
+Nintendo - DSi
+Nintendo - Family BASIC
+Nintendo - Family Computer Disk System
+Nintendo - Family Computer Network System
+Nintendo - Game & Watch
+Nintendo - Game Boy
+Nintendo - Game Boy Advance
+Nintendo - Game Boy Color
+Nintendo - Gamecube
+Nintendo - Kiosk Video Compact Flash
+Nintendo - Nintendo Entertainment System & Famicom
+Nintendo - Pokémon Mini
+Nintendo - Satellaview
+Nintendo - Sufami Turbo
+Nintendo - Super Nintendo Entertainment System & Super Famicom
+Nintendo - Switch
+Nintendo - Virtual Boy
+Nintendo - Wii
+Nintendo - Wii U
+Nokia - N-Gage
+Ouya - Ouya
+Panasonic - 3DO Interactive Multiplayer
+Panasonic - M2
+PC - Battle.net
+PC - Epic Games
+PC - Good Old Games
+PC - Project EGG
+PC - Standalone IBM PC
+PC - Steam
+PC - Ubisoft Connect
+Philips - CD-i
+Philips - Videopac+
+RCA - Studio II
+Sanyo - MBC-550
+Sega - 32X
+Sega - Beena
+Sega - Dreamcast
+Sega - Game Gear
+Sega - Master System - Mark III
+Sega - Mega CD & Sega CD
+Sega - Mega Drive & Genesis
+Sega - PICO
+Sega - Prologue 21
+Sega - Saturn
+Sega - SG-1000
+Seta - Aleck64
+Sharp - MZ-2200
+Sharp - MZ-700
+Sharp - X1
+Sharp - X68000
+Sinclair - ZX Spectrum +3
+SNK - Neo Geo CD
+SNK - NeoGeo Pocket
+SNK - NeoGeo Pocket Color
+Sony - Playstation 1
+Sony - Playstation 2
+Sony - Playstation 3
+Sony - Playstation 4
+Sony - Playstation 5
+Sony - PlayStation Mobile
+Sony - PlayStation Portable
+Sony - PlayStation Vita
+TAB-Austria - Quizard
+TeleNova - Compis
+Texas Instruments - TI-99-4A
+Tiger - Game.com
+Tiger - Gizmondo
+Tomy - Kiss-Site
+Toshiba - Pasopia
+Toshiba - Visicom
+VM Labs - NUON
+VTech - CreatiVision
+VTech - V.Flash & V.Smile Pro
+VTech - V.Smile
+Watara - Supervision
+Welback - Mega Duck
+Yamaha - Copera
+ZAPiT Games - Game Wave Family Entertainment System
+Zeebo - Zeebo
 
 # categories to be displayed in playing tab, no playthrough logged
 [playing]


### PR DESCRIPTION
Somewhat of a more extensive platforms list based on http://redump.org/ & https://datomatic.nointro.org/, figured it can be more specific because editing it after the fact removes the entry for each game. Should give a good baseline to be easy to add other PC based Platforms or VR based games to it. Might add Arcade platforms if there is a interest for this being accepted as a default.